### PR TITLE
Se modifican todos los menú para no usar fechas como filtros donde no…

### DIFF
--- a/app/controllers/informs_controller.rb
+++ b/app/controllers/informs_controller.rb
@@ -25,6 +25,10 @@ class InformsController < ApplicationController
     end
   end
 
+  def index_pending
+    @informs = Inform.where(inf_type: params[:inf_type]).pending.paginate(page: params[:page], per_page: 10)
+  end
+
   def index_oldrecords
     if params[:init_date]
       initial_date = Date.parse(params[:init_date]).beginning_of_day
@@ -83,24 +87,16 @@ class InformsController < ApplicationController
 
   def index_ready
     @tab = :ready
-    # if params[:yi]
-    #   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-    #   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-    #   date_range = initial_date..final_date
-    #   @informs = Inform.where(receive_date: date_range, inf_status: "ready")
-    # else
-    #   @informs = Inform.where(inf_status: "ready")
-    # end
+    
     if params[:init_date]
       initial_date = Date.parse(params[:init_date]).beginning_of_day
       final_date = Date.parse(params[:final_date]).end_of_day
       date_range = initial_date..final_date
+      @informs = Inform.where(delivery_date: date_range, inf_status: "ready")
     else
-      initial_date = 1.day.ago.beginning_of_day
-      final_date = Time.now.end_of_day
-      date_range = initial_date..final_date
+      @informs = Inform.where(inf_status: "ready")
     end
-    @informs = Inform.where(delivery_date: date_range, inf_status: "ready")
+    
   end
 
   def publish
@@ -527,32 +523,13 @@ class InformsController < ApplicationController
 
   def descr_micros
     @tab = :pathologist
-    # if params[:yi]
-    #   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-    #   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-    #   date_range = initial_date..final_date
-    #   @informs = Inform.where(receive_date: date_range, inf_status: nil, pathologist_id: current_user.id).or(Inform.where(receive_date: date_range, inf_status: "revision_cyto", pathologist_id: current_user.id))
-    # else
-    #   @informs = Inform.where(inf_status: nil, pathologist_id: current_user.id).or(Inform.where(inf_status: "revision_cyto", pathologist_id: current_user.id))
-    # end
+
     serializer = %w[id tag_code pathologist_id inf_status receive_date patient_id]
 
-    # if params[:init_date]
-    #   initial_date = Date.parse(params[:init_date]).beginning_of_day
-    #   final_date = Date.parse(params[:final_date]).end_of_day
-    #   date_range = initial_date..final_date
-    # else
-    #   initial_date = 1.day.ago.beginning_of_day
-    #   final_date = Time.now.end_of_day
-    #   date_range = initial_date..final_date
-    # end
-
     if role_admin_allowed?
-      # @informs = Inform.unscoped.where(user_review_date: date_range, inf_status: nil).or(Inform.unscoped.where(user_review_date: date_range, inf_status: "revision_cyto")).order(pathologist_id: :asc)
-      @informs = Inform.unscoped.select(serializer).where(inf_status: nil).or(Inform.unscoped.select(serializer).where(inf_status: "revision_cyto")).order(pathologist_id: :asc).order(tag_code: :asc).paginate(page: params[:page], per_page: 10)
+      @informs = Inform.select(serializer).where(inf_status: nil).or(Inform.select(serializer).where(inf_status: "revision_cyto")).order(pathologist_id: :asc).order(tag_code: :asc).paginate(page: params[:page], per_page: 10)
     else
-      # @informs = Inform.select(serializer).where(user_review_date: date_range, inf_status: nil, pathologist_id: current_user.id).or(Inform.select(serializer).where(user_review_date: date_range, inf_status: "revision_cyto", pathologist_id: current_user.id))
-      @informs = Inform.unscoped.select(serializer).where(inf_status: nil, pathologist_id: current_user.id).or(Inform.unscoped.select(serializer).where(inf_status: "revision_cyto", pathologist_id: current_user.id)).order(tag_code: :asc).paginate(page: params[:page], per_page: 10)
+      @informs = Inform.select(serializer).where(inf_status: nil, pathologist_id: current_user.id).or(Inform.select(serializer).where(inf_status: "revision_cyto", pathologist_id: current_user.id)).order(tag_code: :asc).paginate(page: params[:page], per_page: 10)
     end
 
   end
@@ -676,94 +653,50 @@ class InformsController < ApplicationController
   def distribution
     @tab = :asign
 
-    if params[:init_date]
-      initial_date = Date.parse(params[:init_date]).beginning_of_day
-      final_date = Date.parse(params[:final_date]).end_of_day
-      date_range = initial_date..final_date
-    else
-      initial_date = 1.day.ago.beginning_of_day
-      final_date = Time.now.end_of_day
-      date_range = initial_date..final_date
-    end
-    @slides = Slide.unscoped.where(colored: true, covered: true, tagged: true, created_at: date_range).joins(:inform).select("slides.inform_id").distinct
     @informs = []
     @informs_unassigned = []
-    @informs_first_batch = []
     @informs_rest = []
-    @slides.each do |slide|
-      if slide.inform.slides.count == slide.inform.slides.where(colored: true, covered: true, tagged: true).count
-        if slide.inform.inf_type != 'cito'
-          unless slide.inform.inf_status == "ready" || slide.inform.inf_status == "published" || slide.inform.inf_status == "downloaded"
-            if slide.inform.pathologist_id != nil
-              @informs << slide.inform
-            else
-              @informs_unassigned << slide.inform
-            end
-          end
-        end
-      end
+
+    Inform.by_tagcode.biop.not_ready.each do |inform|
+      @informs << inform if inform.slides_ok? && inform.path_assigned?
+      @informs_unassigned << inform if inform.slides_ok? && !inform.path_assigned?
     end
+
     @informs_first_batch = @informs_unassigned[0..49]
-    if @informs_first_batch == nil
-      @informs_unassigned = []
-    end
-    @informs_rest = @informs_unassigned[50..-1]
-    if @informs_rest == nil
-      @informs_rest = []
-    end
+    @informs_rest = @informs_unassigned[50..-1] if @informs_unassigned[50..-1].present?
 
     @informs2 = []
     @informs2_unassigned = []
-    @informs2_first_batch = []
     @informs2_rest = []
-    @slides.each do |slide|
-      if slide.inform.slides.count == slide.inform.slides.where(colored: true, covered: true, tagged: true).count
-        if slide.inform.inf_type == 'cito'
-          unless slide.inform.inf_status == "ready" || slide.inform.inf_status == "published" || slide.inform.inf_status == "downloaded" || slide.inform.inf_status == "revision"
-            if slide.inform.pathologist_id != nil
-              @informs2 << slide.inform # citos ya asignadas en otro batch, van directo a @informs porque ya tienen patologo/a
-            else
-              @informs2_unassigned << slide.inform
-            end
-          end
-        end
-      end
+
+    Inform.by_tagcode.cyto.not_ready_or_cyto.each do |inform|
+      @informs2 << inform if inform.slides_ok? && inform.path_assigned?
+      @informs2_unassigned << inform if inform.slides_ok? && !inform.path_assigned?
     end
+
+    @informs2_first_batch = @informs2_unassigned[0..49]
+    @informs2_rest = @informs2_unassigned[50..-1] if @informs2_unassigned[50..-1].present?
 
     @already_negative = 0
 
     @informs2.each do |inform|
-      if inform.diagnostics != []
-        if inform.diagnostics.first.result != nil
-          if inform.diagnostics.first.result == 'negativa'
-            if inform.pathologist_id != nil
-              @already_negative = @already_negative + 1
-            end
-          end
-        end
+      if inform.diagnostics.first&.result.present?
+        @already_negative += 1 if inform.cyto_neg? && inform.path_assigned?
       end
     end
 
     @negative_cytos = []
     @informs3_unassigned = []   #Aca solo almaceno las positivas e instatisfactorias. No las saco del arreglo original para no lidiar con offsets
-    if @informs2_unassigned != nil
+    if @informs2_unassigned.present?
       @informs2_unassigned.each do |inform|
-        if inform.diagnostics != []
-          if inform.diagnostics.first.result != nil
-            if inform.diagnostics.first.result == 'positiva'
-              @informs3_unassigned << inform
-            end
-            if inform.diagnostics.first.result == 'insatisfactoria'
-              @informs3_unassigned << inform
-            end
-            if inform.diagnostics.first.result == 'negativa'
-              if inform.pathologist_id != nil
-                @informs2 << inform
-                @already_negative = @already_negative + 1
-              else
-                @negative_cytos << inform
-              end
-
+        if inform.diagnostics.first&.result.present?
+          @informs3_unassigned << inform if inform.cyto_pos_ins?
+          if inform.cyto_neg?
+            if inform.path_assigned?
+              @informs2 << inform
+              @already_negative = @already_negative + 1
+            else
+              @negative_cytos << inform
             end
           end
         end
@@ -782,7 +715,7 @@ class InformsController < ApplicationController
         end
       end
       if @already_negative == negative_pick
-        if @negative_cytos != []
+        if @negative_cytos.present?
           @negative_cytos.each do |inform|
             inform.update(inf_status: "revision", user_review_date: Time.zone.now.to_date) #Se deben marcar como para validación
           end
@@ -791,127 +724,42 @@ class InformsController < ApplicationController
     end
 
     @informs2_first_batch = @informs3_unassigned[0..49]
-    if @informs2_first_batch == nil
-      @informs_unassigned = []
-    end
+    @informs_unassigned = [] if @informs2_first_batch.blank?
+
     @informs2_rest = @informs3_unassigned[50..-1]
-    if @informs2_rest == nil
-      @informs2_rest = []
-    end
-
-
-    pathologist_role_id = Role.where(name: "Patologia").first.id
+    @informs2_rest = [] if @informs2_rest.blank?
+      
+    pathologist_role_id = Role.find_by_name("Patologia").id
     @users = User.where(role_id: pathologist_role_id)
-
-    # @informs_assigned = @informs.where.not(pathologist_id: nil)
-    # @informs_unassigned = @informs.where(pathologist_id: nil)
-    # @informs_first_batch = @informs_unassigned.limit(50)
-    # @informs_rest = @informs_unassigned.offset(50)
   end
 
   def distribution_cyto
-    # if params[:yi]
-    #   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-    #   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-    #   date_range = initial_date..final_date
-    #   # @informs = Inform.where(created_at: date_range).joins("INNER JOIN slides ON slides.colored = true AND slides.covered = true AND slides.tagged = true").distinct
-    #   @slides = Slide.unscoped.where(colored: true, covered: true, tagged: true, created_at: date_range).joins(:inform).select("slides.inform_id").distinct
-    # else
-    #   # @informs = Inform.joins("INNER JOIN slides ON slides.colored = true AND slides.covered = true AND slides.tagged = true").distinct
-    #   @slides = Slide.unscoped.where(colored: true, covered: true, tagged: true).joins(:inform).select("slides.inform_id").distinct
-    # end
-    if params[:init_date]
-      initial_date = Date.parse(params[:init_date]).beginning_of_day
-      final_date = Date.parse(params[:final_date]).end_of_day
-      date_range = initial_date..final_date
-    else
-      initial_date = 1.day.ago.beginning_of_day
-      final_date = Time.now.end_of_day
-      date_range = initial_date..final_date
-    end
-    @slides = Slide.unscoped.where(colored: true, covered: true, tagged: true, created_at: date_range).joins(:inform).select("slides.inform_id").distinct
-
     @informs = []
     @informs_unassigned = []
-    @informs_first_batch = []
     @informs_rest = []
-    @slides.each do |slide|
-      if slide.inform.slides.count == slide.inform.slides.where(colored: true, covered: true, tagged: true).count
-        if slide.inform.cytologist != nil
-          @informs << slide.inform
-        else
-          @informs_unassigned << slide.inform
-        end
-      end
-      @informs_first_batch = @informs_unassigned[0..49]
-      if @informs_first_batch == nil
-        @informs_first_batch = []
-      end
-      @informs_rest = @informs_unassigned[50..-1]
-      if @informs_rest == nil
-        @informs_rest = []
-      end
+
+    Inform.by_tagcode.cyto.not_ready.each do |inform|
+      @informs << inform if inform.slides_ok? && inform.cyto_assigned?
+      @informs_unassigned << inform if inform.slides_ok? && !inform.cyto_assigned?
     end
+
+    @informs_first_batch = @informs_unassigned[0..49]
+    @informs_rest = @informs_unassigned[50..-1] if @informs_unassigned[50..-1].present?
 
     cytologist_role_id = Role.where(name: "Citologia").first.id
     @users = User.where(role_id: cytologist_role_id)
-
-    # @informs_assigned = @informs.where.not(cytologist: nil)
-    # @informs_unassigned = @informs.where(cytologist: nil)
-    # @informs_first_batch = @informs_unassigned.limit(50)
-    # @informs_rest = @informs_unassigned.offset(50)
   end
 
   def assign
     Inform.where(id: params[:inform_ids]).update_all({pathologist_id: params[:pathologist_id].to_i == 0 ? nil : params[:pathologist_id].to_i, user_review_date: Time.zone.now.to_date })
 
-    # if params[:yi] != ""
-    #   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-    #   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-    #   date_range = initial_date..final_date
-
-    #   redirect_to distribution_path + "?di=#{params[:di]}&mi=#{params[:mi]}&yi=#{params[:yi]}&df=#{params[:df]}&mf=#{params[:mf]}&yf=#{params[:yf]}"
-    # else
-    #   redirect_to distribution_path
-    # end
-
-    if params[:init_date]
-      initial_date = Date.parse(params[:init_date]).beginning_of_day
-      final_date = Date.parse(params[:final_date]).end_of_day
-      date_range = initial_date..final_date
-    else
-      initial_date = 1.day.ago.beginning_of_day
-      final_date = Time.now.end_of_day
-      date_range = initial_date..final_date
-    end
-
-    redirect_to distribution_path + "?init_date=" + params[:init_date] + "&final_date=" + params[:final_date]
+    redirect_to distribution_path
   end
 
   def assign_cyto
     Inform.where(id: params[:inform_ids]).update_all({cytologist: params[:cytologist].to_i == 0 ? nil : params[:cytologist].to_i })
 
-    # if params[:yi] != ""
-    #   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-    #   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-    #   date_range = initial_date..final_date
-
-    #   redirect_to distribution_path + "?di=#{params[:di]}&mi=#{params[:mi]}&yi=#{params[:yi]}&df=#{params[:df]}&mf=#{params[:mf]}&yf=#{params[:yf]}"
-    # else
-    #   redirect_to distribution_cyto_path
-    # end
-
-    if params[:init_date]
-      initial_date = Date.parse(params[:init_date]).beginning_of_day
-      final_date = Date.parse(params[:final_date]).end_of_day
-      date_range = initial_date..final_date
-    else
-      initial_date = 1.day.ago.beginning_of_day
-      final_date = Time.now.end_of_day
-      date_range = initial_date..final_date
-    end
-
-    redirect_to distribution_cyto_path + "?init_date=" + params[:init_date] + "&final_date=" + params[:final_date]
+    redirect_to distribution_cyto_path
   end
 
   # GET /informs/1

--- a/app/controllers/list_blocks_controller.rb
+++ b/app/controllers/list_blocks_controller.rb
@@ -11,6 +11,7 @@ class ListBlocksController < ApplicationController
 		@inform = @block.inform
 		@inform.slides.create(slide_tag: params[:block_tag], user_id: current_user.id)	#Se crea un slide con el mismo tag de la sample
 		@block.update(slide_tag: params[:block_tag])	#Se guarda el tag creado en el block para que queden asociados
+		@informs = Inform.joins(:blocks).merge(Block.not_slided).order(tag_code: :asc).uniq
 	end
 
 	def add_block_series
@@ -66,17 +67,17 @@ class ListBlocksController < ApplicationController
 		#   @samplesc = Sample.where(name: "Cassette")
 		# end
 
-		if params[:init_date]
-		  initial_date = Date.parse(params[:init_date]).beginning_of_day
-		  final_date = Date.parse(params[:final_date]).end_of_day
-		  date_range = initial_date..final_date
+		# if params[:init_date]
+		#   initial_date = Date.parse(params[:init_date]).beginning_of_day
+		#   final_date = Date.parse(params[:final_date]).end_of_day
+		#   date_range = initial_date..final_date
 		  
-		else
-		  initial_date = 1.day.ago.beginning_of_day
-		  final_date = Time.now.end_of_day
-		  date_range = initial_date..final_date
-		end
-		@blocks = Block.unscoped.where(created_at: date_range).select(:inform_id).group(:inform_id).distinct
+		# else
+		#   initial_date = 1.day.ago.beginning_of_day
+		#   final_date = Time.now.end_of_day
+		#   date_range = initial_date..final_date
+		# end
+		@blocks = Block.unscoped.select(:inform_id).group(:inform_id).distinct
 		# @samplesc = Sample.where(created_at: date_range, name: "Cassette")
 	end
 
@@ -113,6 +114,7 @@ class ListBlocksController < ApplicationController
 		# @samplesc = Sample.where(name: "Cassette")
 		# @blocks = Block.all
 		get_samplesc_and_blocks
+		@informs = Inform.joins(:blocks).merge(Block.not_slided).order(tag_code: :asc).uniq
 	end
 
 	def block_fok
@@ -147,6 +149,7 @@ class ListBlocksController < ApplicationController
 			@block.update(verified: true, user_id: current_user.id)
 		end
 		@sample.update(included: true, user_id: current_user.id)
+		@informs = Inform.joins(:blocks).merge(Block.not_slided).order(tag_code: :asc).uniq
 	end
 
 	def block_fm1
@@ -157,6 +160,7 @@ class ListBlocksController < ApplicationController
 		# @samplesc = Sample.where(name: "Cassette")
 		# @blocks = Block.all
 		get_samplesc_and_blocks
+		@informs = Inform.joins(:blocks).merge(Block.not_slided).order(tag_code: :asc).uniq
 	end
 
 	def get_nomen(str)

--- a/app/controllers/list_slides_controller.rb
+++ b/app/controllers/list_slides_controller.rb
@@ -5,42 +5,17 @@ class ListSlidesController < ApplicationController
 		@slide = Slide.find(params[:slide_id])
 		@slide.update(colored: !@slide.colored)
 		@informs = Inform.joins(:slides).merge(Slide.not_colored.not_tagged.not_covered).uniq
-		get_slides
 	end
 
 	def tag
 		@slide = Slide.find(params[:slide_id])
 		@slide.update(tagged: !@slide.tagged)
 		@informs = Inform.joins(:slides).merge(Slide.not_colored.not_tagged.not_covered).uniq
-		get_slides
 	end
 
 	def cover
 		@slide = Slide.find(params[:slide_id])
 		@slide.update(covered: !@slide.covered)
 		@informs = Inform.joins(:slides).merge(Slide.not_colored.not_tagged.not_covered).uniq
-		get_slides
-	end
-
-	def get_slides
-		# if params[:yi] != ""
-		#   initial_date = Date.new(params[:yi].to_i, params[:mi].to_i, params[:di].to_i).beginning_of_day
-		#   final_date = Date.new(params[:yf].to_i, params[:mf].to_i, params[:df].to_i).end_of_day
-		#   date_range = initial_date..final_date
-		#   @slides = Slide.unscoped.where(created_at: date_range).select(:inform_id).group(:inform_id).distinct
-		# else
-		#   @slides = Slide.unscoped.all.select(:inform_id).group(:inform_id).distinct
-		# end
-
-		if params[:init_date]
-		  initial_date = Date.parse(params[:init_date]).beginning_of_day
-		  final_date = Date.parse(params[:final_date]).end_of_day
-		  date_range = initial_date..final_date
-		else
-		  initial_date = 1.day.ago.beginning_of_day
-		  final_date = Time.now.end_of_day
-		  date_range = initial_date..final_date
-		end
-		@slides = Slide.unscoped.where(created_at: date_range).select(:inform_id).group(:inform_id).distinct
 	end
 end

--- a/app/controllers/slides_controller.rb
+++ b/app/controllers/slides_controller.rb
@@ -6,7 +6,8 @@ class SlidesController < ApplicationController
   # GET /slides.json
   def index
     @tab = :slides
-    @informs = Inform.joins(:slides).merge(Slide.not_colored.not_tagged.not_covered).uniq
+    # @informs = Inform.joins(:slides).merge(Slide.where(colored: false).or(Slide.where(covered: false).or(Slide.where(tagged: false)))).uniq
+    @informs = Inform.joins(:slides).merge(Slide.not_colored.or(Slide.not_covered).or(Slide.not_tagged)).uniq
   end
 
   # GET /slides/1

--- a/app/views/blocks/_list-blocks.html.erb
+++ b/app/views/blocks/_list-blocks.html.erb
@@ -1,9 +1,8 @@
 <div class="list-blocks">
   <div class="container-fluid">
     <div class="row">
-      <h4>Bloques <%= new_search_range %></h4>
       <div class="col-12 col-lg-12 mx-auto">
-        <% @informs.each do |inform| %>
+        <% informs.each do |inform| %>
           <div class="card bg-light mx-2 mb-3">
             <div class="card-header pl-1 pr-0 pt-0 pb-0">
               <strong>Bloques para informe <%= inform.tag_code %></strong>

--- a/app/views/blocks/index.html.erb
+++ b/app/views/blocks/index.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-12 col-lg-12 mb-3 mx-auto">
     <div class="list-block">
-      <%= render partial: "list-blocks", locals: { blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil } %>
+      <%= render partial: "list-blocks", locals: { informs: @informs, samplesc: @samplesc, edit_objection_id: nil } %>
     </div>
   </div>
 </div>

--- a/app/views/informs/distribution.html.erb
+++ b/app/views/informs/distribution.html.erb
@@ -24,7 +24,7 @@
 								<tr>
 									
 									<!-- <td><%= inform.id %></td> -->
-									<td><%= inform.tag_code %></td>
+									<td><%= inform.tag_code + inform.inf_status.to_s %></td>
 									<!-- <td><%= inform.slides.count %></td> -->
 									<!-- <td><%= inform.slides.where(colored: true, covered: true, tagged: true).count %></td> -->
 									<td><%= User.where(id: inform.pathologist_id).first.try(:fullname) %></td>

--- a/app/views/informs/index_pending.html.erb
+++ b/app/views/informs/index_pending.html.erb
@@ -1,0 +1,76 @@
+<div class="info">
+  <% if params[:inf_type] %>
+    <div class="row">
+      <div class="col-12 col-lg-4">
+        <h4 class="mt-2"><%= @informs.count %> informes pendientes de <%= params[:inf_type] == "clin" ? "clínica" : params[:inf_type] == "hosp" ? "hospital" : "citología" %></h4>
+      </div>
+    </div>
+  <% end %>
+</div>
+<br>
+<div class="container-fluid mt-3">
+  <div class="row">
+    <div class="col-12 col-lg-12 mx-auto">
+      
+      <%= will_paginate @informs, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer %>
+      <table class="table table-striped">
+        <thead class="thead-dark">
+          <tr>
+            <th>Informe</th>
+            <th>Estado</th>
+            <th>Ingreso</th>
+            <th>User</th>
+            <th>Paciente</th>
+            <th>EPS</th>
+            <th>IPS</th>
+            <th>Autoriz</th>
+            <th scope="1"></th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <% @informs.each do |inform| %>
+            <tr>
+              <td>
+                <% if inform.inf_status == "anulado" %>
+                  <del class="anulated">
+                    <%= link_to inform  do %>
+                      <%= inform.tag_code %>
+                    <% end %>
+                  </del>
+                <% else %>
+                  <%= link_to inform  do %>
+                    <%= inform.tag_code %>: <%= inform.inf_status.to_s %>
+                  <% end %>
+                <% end %>
+                
+              </td>
+              <td>
+                <%= render 'inform_status', inform: inform %>
+              </td>
+              <td><%= inform.receive_date.strftime('%d/%m/%Y') %></td>
+              <td><%= User.where(id: inform.user_id).first.try(:initials) %></td>
+              <td>
+                <%= link_to inform.patient  do %>
+                  <%= inform.patient.name1 %> <%= inform.patient.name2 %> <%= inform.patient.lastname1 %> <%= inform.patient.lastname2 %>
+                  <% end %>
+              </td>
+              <td><%= Promoter.where(id: inform.promoter_id).first.try(:initials) %></td>
+              <td><%= Branch.where(id: inform.branch_id).first.try(:initials) %></td>
+              <td><%= inform.prmtr_auth_code %></td>
+              <% if inform.inf_status == "anulado" %>
+                <td><%= link_to 'Restaurar', anulate_inform_path(inform), data: { confirm: '¿Confirmas la operación?' } %></td>
+              <% else %>
+                <td><%= link_to 'Anular', anulate_inform_path(inform), data: { confirm: '¿Confirmas la operación?' } %></td>
+              <% end %>
+              
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= will_paginate @informs, :renderer => WillPaginate::ActionView::Bootstrap4LinkRenderer %>
+    </div>
+  </div>
+</div>
+
+

--- a/app/views/informs/index_ready.html.erb
+++ b/app/views/informs/index_ready.html.erb
@@ -8,14 +8,21 @@
         <div class="row">
           <div class="col-12 col-lg-4">
             <div class="form-group mt-1">
-
-              <%= date_field_tag :init_date, Date.parse(params[:init_date]), class: "form-control input" %>
+              <%  if params[:init_date].present? %>
+                <%= date_field_tag :init_date, Date.parse(params[:init_date]), class: "form-control input" %>
+              <% else %>
+                <%= date_field_tag :init_date, nil.to_s, class: "form-control input" %>
+              <% end %>
+              
             </div>
           </div>
           <div class="col-12 col-lg-4">
             <div class="form-group mt-1">
-
-              <%= date_field_tag :final_date, Date.parse(params[:final_date]), class: "form-control input" %>
+              <%  if params[:final_date].present? %>
+                <%= date_field_tag :final_date, Date.parse(params[:final_date]), class: "form-control input" %>
+              <% else %>
+                <%= date_field_tag :final_date, nil.to_s, class: "form-control input" %>
+              <% end %>
             </div>
           </div>
           <div class="col-12 col-lg-4">

--- a/app/views/informs/index_revision.html.erb
+++ b/app/views/informs/index_revision.html.erb
@@ -23,7 +23,7 @@
             <tr>
               <td>
                 <%= link_to show_revision_inform_path(inform), local: true  do %>
-                  <%= inform.tag_code %>
+                  <%= inform.tag_code + ": " + inform.inf_status %>
                 <% end %>
               </td>
               <td><%= User.where(id: inform.pathologist_id).first.try(:initials) %></td>

--- a/app/views/layouts/_blocks_navbar.html.erb
+++ b/app/views/layouts/_blocks_navbar.html.erb
@@ -22,23 +22,11 @@
               Coloración
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= link_to "C: Hoy", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Ayer", processing_slides_coloring_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Antier", processing_slides_coloring_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Esta semana", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Este mes", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
+              <%= link_to "Placas Clínica: C", processing_slides_coloring_slides_path + "?inf_type=clin", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "H: Hoy", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Ayer", processing_slides_coloring_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Antier", processing_slides_coloring_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Esta semana", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Este mes", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
+              <%= link_to "Placas Hospital: H", processing_slides_coloring_slides_path + "?inf_type=hosp", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "K: Hoy", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Ayer", processing_slides_coloring_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Antier", processing_slides_coloring_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Esta semana", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Este mes", processing_slides_coloring_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
+              <%= link_to "Placas Citologías: K", processing_slides_coloring_slides_path + "?inf_type=cito", class: "dropdown-item" %>
             </div>
           </li>
           <li class="nav-item dropdown <%= 'active' if @tab == :cover %>">
@@ -46,24 +34,11 @@
               Cubrimiento
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= link_to "C: Hoy", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Ayer", processing_slides_covering_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Antier", processing_slides_covering_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Esta semana", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Este mes", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
+              <%= link_to "Placas Clínica: C", processing_slides_covering_slides_path + "?inf_type=clin", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "H: Hoy", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Ayer", processing_slides_covering_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Antier", processing_slides_covering_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Esta semana", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Este mes", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
+              <%= link_to "Placas Hospital: H", processing_slides_covering_slides_path + "?inf_type=hosp", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "K: Hoy", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Ayer", processing_slides_covering_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Antier", processing_slides_covering_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Esta semana", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Este mes", processing_slides_covering_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <div class="dropdown-divider"></div>
+              <%= link_to "Placas Citología: K", processing_slides_covering_slides_path + "?inf_type=cito", class: "dropdown-item" %>
             </div>
           </li>
           <li class="nav-item dropdown <%= 'active' if @tab == :tag %>">
@@ -71,24 +46,11 @@
               Rotulado
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= link_to "C: Hoy", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Ayer", processing_slides_tagging_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Antier", processing_slides_tagging_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Esta semana", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
-              <%= link_to "C: Este mes", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
+              <%= link_to "Placas Clínica: C", processing_slides_tagging_slides_path + "?inf_type=clin", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "H: Hoy", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Ayer", processing_slides_tagging_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Antier", processing_slides_tagging_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Esta semana", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
-              <%= link_to "H: Este mes", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
+              <%= link_to "Placas Hospital: H", processing_slides_tagging_slides_path + "?inf_type=hosp", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "K: Hoy", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Ayer", processing_slides_tagging_slides_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Antier", processing_slides_tagging_slides_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Esta semana", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <%= link_to "K: Este mes", processing_slides_tagging_slides_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
-              <div class="dropdown-divider"></div>
+              <%= link_to "Placas Citología: K", processing_slides_tagging_slides_path + "?inf_type=cito", class: "dropdown-item" %>
             </div>
           </li>
           <li class="nav-item dropdown <%= 'active' if @tab == :asign %>">
@@ -96,19 +58,9 @@
               Asignar informes
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownInf">
-              <p class="dropdown-item">Patología</p>
-              <%= link_to "Hoy", distribution_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Ayer", distribution_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Antier", distribution_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Esta semana", distribution_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Este mes", distribution_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
+              <%= link_to "Patología", distribution_path, class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <p class="dropdown-item">Citología</p>
-              <%= link_to "Hoy", distribution_cyto_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Ayer", distribution_cyto_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Antier", distribution_cyto_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Esta semana", distribution_cyto_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Este mes", distribution_cyto_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
+              <%= link_to "Citología", distribution_cyto_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
             </div>
           </li>
         <% end %>

--- a/app/views/layouts/_informs_navbar.html.erb
+++ b/app/views/layouts/_informs_navbar.html.erb
@@ -13,6 +13,8 @@
               Clínica
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <%= link_to "PENDIENTES", index_pending_informs_path + "?inf_type=clin", class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
               <%= link_to "Hoy", informs_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Ayer", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Antier", informs_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
@@ -31,6 +33,8 @@
               Hospital
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <%= link_to "PENDIENTES", index_pending_informs_path + "?inf_type=hosp", class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
               <%= link_to "Hoy", informs_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Ayer", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Antier", informs_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
@@ -49,6 +53,8 @@
               Citología
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+              <%= link_to "PENDIENTES", index_pending_informs_path + "?inf_type=cito", class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
               <%= link_to "Hoy", informs_path + "?init_date=" + Date.today.strftime("%d-%m-%Y") + "&final_date=" + Date.today.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
               <%= link_to "Ayer", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
               <%= link_to "Antier", informs_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
@@ -72,19 +78,15 @@
               <%= link_to "Citología", descr_micros_cyto_informs_path, class: "dropdown-item" %>
             </div>
           </li>
-          <li class="nav-item dropdown <%= 'active' if @tab == :revision %>">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownInf" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              Validación
-            </a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdownInf">
-              <%= link_to "Validación", index_revision_informs_path, class: "dropdown-item" %>
-            </div>
+          <li class="nav-item <%= 'active' if @tab == :revision %>">
+            <%= link_to "Validación", index_revision_informs_path, class: "nav-link" %>
           </li>
           <li class="nav-item dropdown <%= 'active' if @tab == :ready %>">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownInf" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Estado
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownInf">
+              <%= link_to "TODOS listos para publicar", informs_index_ready_path, class: "dropdown-item" %>
               <%= link_to "Listos para publicar hoy", informs_index_ready_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
               <%= link_to "Listos para publicar de ayer", informs_index_ready_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
               <%= link_to "Listos para publicar de esta semana", informs_index_ready_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>

--- a/app/views/layouts/_main_navbar.html.erb
+++ b/app/views/layouts/_main_navbar.html.erb
@@ -139,19 +139,19 @@
               Informes
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <p class="dropdown-item">Clínica</p>
+              <%= link_to "Clínica PENDIENTES", index_pending_informs_path + "?inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Ayer y hoy", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Esta semana", informs_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Este mes", informs_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <%= link_to "Desde el mes pasado", informs_path + "?init_date=" + 1.month.ago.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=clin", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <p class="dropdown-item">Hospital</p>
+              <%= link_to "Hospital PENDIENTES", index_pending_informs_path + "?inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Ayer y hoy", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Esta semana", informs_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Este mes", informs_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <%= link_to "Desde el mes pasado", informs_path + "?init_date=" + 1.month.ago.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=hosp", class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <p class="dropdown-item">Citología</p>
+              <%= link_to "Citología PENDIENTES", index_pending_informs_path + "?inf_type=cito", class: "dropdown-item" %>
               <%= link_to "Ayer y hoy", informs_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
               <%= link_to "Esta semana", informs_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
               <%= link_to "Este mes", informs_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&inf_type=cito", class: "dropdown-item" %>
@@ -167,19 +167,9 @@
               Asignar informes
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownInf">
-              <p class="dropdown-item">Patología</p>
-              <%= link_to "Hoy", distribution_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Ayer", distribution_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Antier", distribution_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Esta semana", distribution_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Este mes", distribution_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
+              <%= link_to "Patología", distribution_path, class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <p class="dropdown-item">Citología</p>
-              <%= link_to "Hoy", distribution_cyto_path + "?init_date=" + Time.zone.now.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Ayer", distribution_cyto_path + "?init_date=" + 1.day.ago.strftime("%d-%m-%Y") + "&final_date=" + 1.day.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Antier", distribution_cyto_path + "?init_date=" + 2.days.ago.strftime("%d-%m-%Y") + "&final_date=" + 2.days.ago.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Esta semana", distribution_cyto_path + "?init_date=" + Time.zone.now.beginning_of_week.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
-              <%= link_to "Este mes", distribution_cyto_path + "?init_date=" + Time.zone.now.beginning_of_month.strftime("%d-%m-%Y") + "&final_date=" + Time.zone.now.strftime("%d-%m-%Y"), class: "dropdown-item" %>
+              <%= link_to "Citología", distribution_cyto_path, class: "dropdown-item" %>
             </div>
           </li>
           <li class="nav-item">

--- a/app/views/list_blocks/add_block_slide.js.erb
+++ b/app/views/list_blocks/add_block_slide.js.erb
@@ -3,7 +3,7 @@
 	function refresh2() {
 
 	  $('div.list-blocks').remove();
-	  $('div.list-block').append('<%= j render "blocks/list-blocks", blocks: @blocks, edit_objection_id: nil %>');
+	  $('div.list-block').append('<%= j render "blocks/list-blocks", blocks: @blocks, informs: @informs, edit_objection_id: nil %>');
 
 	  
 	  $('div.fast-bar').append('<%= j render "ok-message", message: "editado" %>');

--- a/app/views/list_blocks/block_fm1.js.erb
+++ b/app/views/list_blocks/block_fm1.js.erb
@@ -3,7 +3,7 @@
 	function refresh2() {
 
 	  $('div.list-blocks').remove();
-	  $('div.list-block').append('<%= j render "blocks/list-blocks", blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
+	  $('div.list-block').append('<%= j render "blocks/list-blocks", informs: @informs, blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
 
 	  
 	  $('div.fast-bar').append('<%= j render "ok-message", message: "editado" %>');

--- a/app/views/list_blocks/block_fok.js.erb
+++ b/app/views/list_blocks/block_fok.js.erb
@@ -3,7 +3,7 @@
 	function refresh2() {
 
 	  $('div.list-blocks').remove();
-	  $('div.list-block').append('<%= j render "blocks/list-blocks", blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
+	  $('div.list-block').append('<%= j render "blocks/list-blocks", informs: @informs, blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
 
 	  
 	  $('div.fast-bar').append('<%= j render "ok-message", message: "editado" %>');

--- a/app/views/list_blocks/block_fp1.js.erb
+++ b/app/views/list_blocks/block_fp1.js.erb
@@ -3,7 +3,7 @@
 	function refresh2() {
 
 	  $('div.list-blocks').remove();
-	  $('div.list-block').append('<%= j render "blocks/list-blocks", blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
+	  $('div.list-block').append('<%= j render "blocks/list-blocks", informs: @informs, blocks: @blocks, samplesc: @samplesc, edit_objection_id: nil %>');
 
 	  
 	  $('div.fast-bar').append('<%= j render "ok-message", message: "editado" %>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,7 @@ Rails.application.routes.draw do
         get :last20
         get :index_oldrecords
         get :index_oldcitos
+        get :index_pending
 
         put :publish
         put :unpublish


### PR DESCRIPTION
Se modifican todos los menú para no usar fechas como filtros donde no se necesita. Se crean menus para evidenciar informes con inf_status en nil, es decir, incompletos. Se refactora codigo de asignacion para biopsias y citos de modo que muestre todo lo que esta pendiente, sin filtro temporal: